### PR TITLE
:wrench:  use default render type

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -12,7 +12,6 @@ body:
       label: Describe the bug
       description: A clear and concise description of what the bug is.
       placeholder: Tell us what you see!
-      render: Markdown
     validations:
       required: true
   - type: textarea
@@ -24,7 +23,6 @@ body:
         2. Click on '....'
         3. Scroll down to '....'
         4. See error
-      render: Markdown
     validations:
       required: true
   - type: input
@@ -44,13 +42,11 @@ body:
     attributes:
       label: Screenshots
       description: If applicable, add screenshots to help explain your problem.
-      render: Markdown
     validations:
       required: false
   - type: textarea
     attributes:
       label: Additional context
       description: Add any other context about the problem here.
-      render: Markdown
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -11,7 +11,6 @@ body:
     attributes:
       label: Describe what kind of feature
       description: A clear and concise description of what you want to happen.
-      render: Markdown
     validations:
       required: true
   - type: textarea
@@ -19,6 +18,5 @@ body:
       label: Describe what does the proposed API look like?
       placeholder: | 
         Describe how you propose to solve the problem and provide code samples of how the API would work once implemented. Note that you can use Markdown to format your code blocks.
-      render: Markdown
     validations:
       required: true


### PR DESCRIPTION
### What

`render: Markdown` will convert text into

```markdown
text
```

### Warning

- [ ] - Any warnings?
